### PR TITLE
Change Github URLs to use HTTPs instead of SSH

### DIFF
--- a/building.html
+++ b/building.html
@@ -64,16 +64,16 @@ release snapshot tarballs of the releases. To build from the upstream
 repositories:</p>
 
 <pre><code>git clone git://sourceware.org/git/binutils-gdb.git
-git clone git@github.com:openrisc/or1k-gcc gcc
+git clone https://github.com/openrisc/or1k-gcc.git gcc
 git clone git://sourceware.org/git/newlib-cygwin.git newlib
 </code></pre>
 
 <p>In case you want to build from the development sources you need to
 check out the following set of repositories:</p>
 
-<pre><code>git clone git@github.com:openrisc/or1k-src binutils-gdb
-git clone git@github.com:openrisc/or1k-gcc gcc
-git clone git@github.com:openrisc/newlib.git
+<pre><code>git clone https://github.com/openrisc/or1k-src.git binutils-gdb
+git clone https://github.com/openrisc/or1k-gcc.git gcc
+git clone https://github.com/openrisc/newlib.git
 </code></pre>
 
 <p>Those repositories differ from the upstream repositories in that there might be changes in the upstream code that have not yet been merged, but also architecture specific code that is not yet in the upstream distribution.</p>


### PR DESCRIPTION
This allows checkouts also for non-authenticated github users.
