### PR TITLE
or1k: Make open reentrant

### DIFF
--- a/libgloss/or1k/syscalls.c
+++ b/libgloss/or1k/syscalls.c
@@ -124,7 +124,7 @@ _lseek_r(struct _reent *reent, int file, _off_t ptr, int dir)
 }
 
 int
-_open(struct _reent *reent, char *file, int flags, int mode)
+_open_r(struct _reent *reent, const char *file, int flags, int mode)
 {
 	reent->_errno = ENOSYS;
 	return -1;


### PR DESCRIPTION
or1k uses reentrant calls by default, but there was no open_r defined
which caused failure in C++/C code such as:

int main() { std::cout << "test\n";  return 0; }

or

int main() {open(".", 0);}
