### PR TITLE
libgloss: or1k: If available call the init for init_array

### DIFF
--- a/libgloss/or1k/crt0.S
+++ b/libgloss/or1k/crt0.S
@@ -36,6 +36,7 @@
       the obvious things..                                                    */
 /* -------------------------------------------------------------------------- */
 
+#include "newlib.h"
 #include "include/or1k-asm.h"
 #include "include/or1k-sprs.h"
 
@@ -95,6 +96,11 @@ _or1k_exception_stack_size:	.word EXCEPTION_STACK_SIZE
   Load NPC into r3, EPCR into r4
                                                                               */
 /* -------------------------------------------------------------------------- */
+
+#ifdef HAVE_INITFINI_ARRAY
+#define _init	__libc_init_array
+#define _fini	__libc_fini_array
+#endif
 
 #define GPR_BUF_OFFSET(x) (x << 2)
 


### PR DESCRIPTION
There was an issue revealed in gdb testing where C++ virtual tables
were not getting properly initialized.  This seems to be due to the
c++ global constructors moving from ctors to init_array.

This fix makes sure we call the proper method for initializing the
constructors in all places.
