### PR TITLE
libgloss: Remove duplicate definition of environ

### DIFF
--- a/libgloss/or1k/syscalls.c
+++ b/libgloss/or1k/syscalls.c
@@ -56,9 +56,6 @@ _close_r(struct _reent *reent, int fildes)
 	return -1;
 }
 
-char *__env[1] = { 0 };
-char **environ = __env;
-
 int
 _execve_r(struct _reent *reent, const char *name, char * const *argv,
 		char * const *env)


### PR DESCRIPTION
Environ is defined in libgloss and libc:
- libgloss/or1k/syscalls.c
- libc/stdlib/environ.c

When linking we sometimes get errors:
or1k-elf-g++ test.o -mnewlib -mboard=or1ksim -lm -o  test
/opt/shorne/software/or1k/lib/gcc/or1k-elf/5.3.0/../../../../or1k-elf/lib/libor1k.a(syscalls.o):(.data+0x0):
multiple definition of `environ'
/opt/shorne/software/or1k/lib/gcc/or1k-elf/5.3.0/../../../../or1k-elf/lib/libc.a(lib_a-environ.o):(.data+0x0):
first defined here
collect2: error: ld returned 1 exit status

This doesnt happen after the fix. Basic things build fine too.
