### PR TITLE
build: Remove sim and or1ksim disable options

### DIFF
--- a/building.html
+++ b/building.html
@@ -164,7 +164,7 @@ cd ..
 architecture:</p>
 
 <pre><code>mkdir build-gdb; cd build-gdb
-../gdb/configure --target=or1k-elf --prefix=$PREFIX --disable-itcl --disable-tk --disable-tcl --disable-winsup --disable-gdbtk --disable-libgui --disable-rda --disable-sid --disable-sim --disable-or1ksim --with-sysroot --disable-newlib --disable-libgloss --disable-gas --disable-ld --disable-binutils --disable-gprof --with-system-zlib
+../gdb/configure --target=or1k-elf --prefix=$PREFIX --disable-itcl --disable-tk --disable-tcl --disable-winsup --disable-gdbtk --disable-libgui --disable-rda --disable-sid --with-sysroot --disable-newlib --disable-libgloss --disable-gas --disable-ld --disable-binutils --disable-gprof --with-system-zlib
 make
 make install
 cd ..


### PR DESCRIPTION
In the latest version of gdb these now work and should be enabled.
or1ksim has been removed and replaced with a native cgen based
simulator.
