### PR TITLE
Update the instructions to correspond to updated mpfr version

### DIFF
--- a/building.html
+++ b/building.html
@@ -107,9 +107,9 @@ ln -s ../gmp-6.1.0 gcc/gmp
 wget ftp://ftp.gnu.org/gnu/mpc/mpc-1.0.3.tar.gz
 tar -xzf mpc-1.0.3.tar.gz
 ln -s ../mpc-1.0.3 gcc/mpc
-wget http://www.mpfr.org/mpfr-current/mpfr-3.1.4.tar.xz
-tar -xf mpfr-3.1.4.tar.xz
-ln -s ../mpfr-3.1.4 gcc/mpfr</code></pre>
+wget http://www.mpfr.org/mpfr-current/mpfr-3.1.6.tar.xz
+tar -xf mpfr-3.1.6.tar.xz
+ln -s ../mpfr-3.1.6 gcc/mpfr</code></pre>
 
 <h3>Build binutils</h3>
 


### PR DESCRIPTION
Existing [url](http://www.mpfr.org/mpfr-current/mpfr-3.1.4.tar.xz) for mpfr-3.1.4 shows 404 error. This commit updates
the link to mpfr-3.1.6 and also updates next two commands.

Signed-off-by: Rohit Singh <rohit.singh@gmx.com>